### PR TITLE
Refactored some logic inside zfaModal and put them inside zfaModalFac…

### DIFF
--- a/foundation-apps-modal.js
+++ b/foundation-apps-modal.js
@@ -127,48 +127,60 @@
             }
         })
         .config(['zfaModalProvider', function(zfaModalProvider) {
-            zfaModalProvider('alert', {
-                controller: ['$scope', 'ok', 'message', function($scope, ok, message) {
-                    $scope.ok = ok;
-                    $scope.message = message;
-                }],
-                template: '<div zf-modal="" overlay="false" overlay-close="false" class="tiny dialog"><a class="close-button" zf-close="">×</a><h4>{{message}}</h4><a class="button primary" ng-click="resolve()">{{ok}}</a></div>',
-                locals: {
-                    ok: "OK",
-                    message: ""
+
+            var modalSamples = [
+                {
+                    id:'alert',
+                    config: {
+                        controller: ['$scope', 'ok', 'message', function($scope, ok, message) {
+                            $scope.ok = ok;
+                            $scope.message = message;
+                        }],
+                        template: '<div zf-modal="" overlay="false" overlay-close="false" class="tiny dialog"><a class="close-button" zf-close="">×</a><h4>{{message}}</h4><a class="button primary" ng-click="resolve()">{{ok}}</a></div>',
+                        locals: {
+                            ok: "OK",
+                            message: ""
+                        }
+                    }
+                },
+                {
+                    id:'confirm',
+                    config: {
+                        controller: ['$scope', 'ok', 'cancel', 'message', function($scope, ok, cancel, message) {
+                            $scope.ok = ok;
+                            $scope.cancel = cancel;
+                            $scope.message = message;
+                        }],
+                        template: '<div zf-modal="" overlay="false" overlay-close="false" class="tiny dialog"><a class="close-button" zf-close="">×</a><h4>{{message}}</h4><a class="button primary" ng-click="resolve()">{{ok}}</a><a class="button secondary" ng-click="reject()">{{cancel}}</a></div>',
+                        locals: {
+                            ok: "OK",
+                            cancel: "Cancel",
+                            message: ""
+                        }
+                    }
+                },
+                {
+                    id:'prompt',
+                    config: {
+                        controller: ['$scope', 'ok', 'cancel', 'message', 'value', function($scope, ok, cancel, message, value) {
+                            $scope.ok = ok;
+                            $scope.cancel = cancel;
+                            $scope.message = message;
+                            $scope.value = value;
+                        }],
+                        template: '<div zf-modal="" overlay="false" overlay-close="false" class="tiny dialog"><a class="close-button" zf-close="">×</a><h4>{{message}}</h4><label><input type="text" ng-model="value"></label><a class="button primary" ng-click="resolve(value)">{{ok}}</a><a class="button secondary" ng-click="reject()">{{cancel}}</a></div>',
+                        locals: {
+                            ok: "OK",
+                            cancel: "Cancel",
+                            message: "",
+                            value: ""
+                        }
+                    }
                 }
-            });
-        }])
-        .config(['zfaModalProvider', function(zfaModalProvider) {
-            zfaModalProvider('confirm', {
-                controller: ['$scope', 'ok', 'cancel', 'message', function($scope, ok, cancel, message) {
-                    $scope.ok = ok;
-                    $scope.cancel = cancel;
-                    $scope.message = message;
-                }],
-                template: '<div zf-modal="" overlay="false" overlay-close="false" class="tiny dialog"><a class="close-button" zf-close="">×</a><h4>{{message}}</h4><a class="button primary" ng-click="resolve()">{{ok}}</a><a class="button secondary" ng-click="reject()">{{cancel}}</a></div>',
-                locals: {
-                    ok: "OK",
-                    cancel: "Cancel",
-                    message: ""
-                }
-            });
-        }])
-        .config(['zfaModalProvider', function(zfaModalProvider) {
-            zfaModalProvider('prompt', {
-                controller: ['$scope', 'ok', 'cancel', 'message', 'value', function($scope, ok, cancel, message, value) {
-                    $scope.ok = ok;
-                    $scope.cancel = cancel;
-                    $scope.message = message;
-                    $scope.value = value;
-                }],
-                template: '<div zf-modal="" overlay="false" overlay-close="false" class="tiny dialog"><a class="close-button" zf-close="">×</a><h4>{{message}}</h4><label><input type="text" ng-model="value"></label><a class="button primary" ng-click="resolve(value)">{{ok}}</a><a class="button secondary" ng-click="reject()">{{cancel}}</a></div>',
-                locals: {
-                    ok: "OK",
-                    cancel: "Cancel",
-                    message: "",
-                    value: ""
-                }
-            });
+            ];
+
+            for(var i = 0;i<modalSamples.length;i++){
+                zfaModalProvider.register(modalSamples[i].id,modalSamples[i].config)
+            }
         }]);
 })();

--- a/foundation-apps-modal.js
+++ b/foundation-apps-modal.js
@@ -5,7 +5,7 @@
         .provider('zfaModal', function () {
             var configs = {};
             return {
-                setModal: function (modalId, config) {
+                register: function (modalId, config) {
                     if (typeof modalId === 'string') {
                         configs[modalId] = config;
                     }else{

--- a/foundation-apps-modal.js
+++ b/foundation-apps-modal.js
@@ -2,120 +2,129 @@
     'use strict';
     
     angular.module('zfaModal', ['foundation'])
-        .provider('zfaModal', function() {
+        .provider('zfaModal', function () {
             var configs = {};
-
-            function provider(id, config) {
-                if (typeof id != 'string') throw new Error("zfaModalProvider: id should be defined");
-                configs[id] = config;
-            }
-
-            provider.$get = function(FoundationApi, $controller, $rootScope, $http, $q, $compile, $timeout, $window, $templateCache) {
-                for (var id in configs) {
-                    if (!configs.hasOwnProperty(id)) continue;
-                    if (modalFactory[id]) throw new Error("zfaModal: forbidden id: " + id);
-
-                    modalFactory[id] = function(_config, locals) {
-                        var config = angular.extend({}, _config);
-                        config.locals = angular.extend({}, config.locals, locals);
-                        return modalFactory(config);
-                    }.bind(null, configs[id]);
-                }
-
-                return modalFactory;
-
-                function modalFactory(config) {
-                    config = angular.extend({}, config);
-
-                    var defer = $q.defer(), template;
-
-                    if(config.templateUrl) {
-                        template = $templateCache.get(config.templateUrl);
-
-                        if (template) {
-                            defer.resolve(Array.isArray(template) ? template[0] : template);
-                        } else {
-                            $http.get(config.templateUrl, {
-                                cache: $templateCache
-                            }).then(function(response) {
-                                defer.resolve(response.data);
-                            });
+            return {
+                setModal: function (modalId, config) {
+                    if (typeof modalId === 'string') {
+                        configs[modalId] = config;
+                    }else{
+                        throw new Error('zfaModalProvider: modalId should be defined');
+                    }
+                },
+                $get: function (zfaModalFactory, FoundationApi) {
+                    return {
+                        open: function (modalId, modalConfig) {
+                            var newConfig = configs[modalId];
+                            newConfig.locals = angular.extend({}, newConfig.locals, modalConfig); //Overwrite old config
+                            return zfaModalFactory.createModal(newConfig);
+                        },
+                        close: function (id) {
+                            FoundationApi.publish(id, 'close');
                         }
-                    } else if (config.template) {
-                        defer.resolve(config.template);
-                    } else {
-                        throw new Error("zfaModal: template should be defined");
                     }
 
-                    return defer.promise
-                        .then(function(template) {
-                            var defer = $q.defer();
+                }
+            }
+        })
+        .factory('zfaModalFactory', function(FoundationApi, $controller, $rootScope, $http, $q, $compile, $timeout, $window, $templateCache) {
 
-                            var id = FoundationApi.generateUuid();
+            function createModal(config) {
 
-                            var element = angular.element(template)
-                                .attr('id', id);
+                var defer = $q.defer(), cachedTemplate;
 
-                            var props = {
-                                'animationIn': 'animation-in',
-                                'animationOut': 'animation-out',
-                                'overlay': 'overlay',
-                                'overlayClose': 'overlay-close'
-                            };
+                if(config.templateUrl) {
+                    cachedTemplate = $templateCache.get(config.templateUrl);
 
-                            for (var prop in props) {
-                                if (!props.hasOwnProperty(prop)) continue;
-                                if(config[prop] !== undefined) element.attr(props[prop], config[prop]);
-                            }
-
-                            var container = angular.element(config.container || $window.document.body) ;
-                            container.append(element);
-
-                            var scope = $rootScope.$new();
-                            scope.active = true;
-                            scope.resolve = defer.resolve.bind(defer);
-                            scope.reject = defer.reject.bind(defer);
-
-                            $compile(element)(scope);
-
-                            if (config.controller) {
-                                $controller(config.controller, angular.extend({}, config.locals, { $scope: scope, zfaModalDefer: defer }));
-                            }
-
-                            FoundationApi.publish(id, 'show');
-
-                            FoundationApi.subscribe(id, function(msg) {
-                                switch (msg) {
-                                    case 'toggle':
-                                        if (!scope.active) break;
-                                    case 'close':
-                                    case 'hide':
-                                        defer.reject(msg);
-
-                                        $timeout(function() {
-                                            element.remove();
-                                            scope.$destroy();
-                                        }, 3000);
-
-                                        FoundationApi.unsubscribe(id);
-
-                                        break;
-                                }
-                            });
-
-                            defer.promise.finally(function() {
-                                FoundationApi.publish(id, 'close');
-                                FoundationApi.unsubscribe(id);
-                            });
-
-                            return defer.promise;
+                    if (cachedTemplate) {
+                        defer.resolve(Array.isArray(cachedTemplate) ? cachedTemplate[1] : cachedTemplate);
+                    } else {
+                        $http.get(config.templateUrl, {
+                            cache: $templateCache
+                        }).then(function(response) {
+                            defer.resolve(response.data);
                         });
-                };
-            };
+                    }
 
-            provider.$get.$inject = ['FoundationApi', '$controller', '$rootScope', '$http', '$q', '$compile', '$timeout', '$window', '$templateCache'];
+                } else if (config.template) {
+                    defer.resolve(config.template);
+                } else {
+                    throw new Error('zfaModal: template should be defined');
+                }
 
-            return provider;
+                return defer.promise.then(function (template) {
+                    var defer = $q.defer();
+
+                    // Attach properties
+                    var id = config.id || FoundationApi.generateUuid(); //If config does not have an id yet, create one
+                    var element = angular.element(template).attr('id', id);
+
+                    var props = {
+                        'animationIn': 'animation-in',
+                        'animationOut': 'animation-out',
+                        'overlay': 'overlay',
+                        'overlayClose': 'overlay-close'
+                    };
+
+                    for (var prop in props) {
+                        if (props.hasOwnProperty(prop) && config[prop] !== undefined){
+                            element.attr(props[prop], config[prop]);
+                        }
+                    }
+
+                    var container = config.container || $window.document.body;
+                    angular.element(container).append(element); // attach the element to the container
+
+                    var scope = $rootScope.$new();
+                    scope.active = true;
+                    scope.resolve = defer.resolve.bind(defer);
+                    scope.reject = defer.reject.bind(defer);
+
+                    $compile(element)(scope);
+
+                    if (config.controller) {
+                        $controller(
+                            config.controller,
+                            angular.extend({}, config.locals, {
+                                $scope: scope,
+                                zfaModalDefer: defer
+                            })
+                        );
+                    }
+
+                    // Register events with foundation api
+                    FoundationApi.publish(id, 'show');
+
+                    FoundationApi.subscribe(id, function(msg) {
+                        switch (msg) {
+                            case 'toggle':
+                                if (!scope.active) break;
+                            case 'close':
+                            case 'hide':
+                                defer.reject(msg);
+
+                                $timeout(function() {
+                                    element.remove();
+                                    scope.$destroy();
+                                }, 3000);
+
+                                FoundationApi.unsubscribe(id);
+                                break;
+                        }
+                    });
+
+                    defer.promise.finally(function() {
+                        FoundationApi.publish(id, 'close');
+                        FoundationApi.unsubscribe(id);
+                    });
+
+                    return defer.promise;
+                });
+            }
+
+            return{
+                createModal:createModal
+            }
         })
         .config(['zfaModalProvider', function(zfaModalProvider) {
             zfaModalProvider('alert', {


### PR DESCRIPTION
I extracted some of the logic inside `zfaModal`to `zfaModalFactory`. What I have achieved in this branch:

_ Simplified, reformatted, and refactored code to have a better SoS (Separation of Concern).
_ Fixed a small issue with `cachedTemplate`when you try to retrieve it from `config.templateUrl`.
_ Allowed the user to pass in a customized modal id.

Doing this way will change the current API of `zfaModal`, so we also need to update the README as well.
